### PR TITLE
Change `framer-motion` to optional peer dependency

### DIFF
--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -25,6 +25,11 @@
     "react-dom": "^17.0.2",
     "styled-components": "^5.3.5"
   },
+  "peerDependenciesMeta": {
+    "framer-motion": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/dedent": "^0.7.0",
     "@types/jest": "^28.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,6 +1845,9 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     styled-components: ^5.3.5
+  peerDependenciesMeta:
+    framer-motion:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
If use peerDependenciesMeta we can skip a warning message whenit's not installed.
- [yarn docs](https://yarnpkg.com/configuration/manifest#peerDependenciesMeta)
- [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta)
